### PR TITLE
Declare dependency on Emacs 24

### DIFF
--- a/github-clone.el
+++ b/github-clone.el
@@ -7,7 +7,7 @@
 ;; Version: 0.1
 ;; URL: https://github.com/dgtized/github-clone.el
 ;; Keywords: vc, tools
-;; Package-Requires: ((gh "0.7.2") (magit "1.2.0"))
+;; Package-Requires: ((gh "0.7.2") (magit "1.2.0") (emacs "24"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
`eieio` is not available in Emacs 23, and the `lexical-binding` setting is also specific to Emacs 24. Best, then, to require that Emacs version.

(In relation to https://github.com/milkypostman/melpa/pull/1898)
