### PR TITLE
Fork and add remote functions

### DIFF
--- a/github-clone.el
+++ b/github-clone.el
@@ -108,6 +108,33 @@
           (oref (oref (gh-users-get (gh-users-api "api")) :data) :login)))
   github-clone--user)
 
+(defun github-clone-get-repo-name-from-remote (&optional remote)
+  (unless remote
+    (setq remote
+          (magit-read-remote "Select a remote")))
+  (github-clone-repo-name
+   (magit-get "remote" remote "url")))
+
+;;;###autoload
+(defun github-clone-fork-remote (&optional remote)
+  "Fork REMOTE to the current user."
+  (interactive (list (magit-read-remote "Select a remote to fork")))
+  (cl-destructuring-bind (user . repo)
+      (github-clone-get-repo-name-from-remote remote)
+    (github-clone-fork-repo (github-clone-info user repo))))
+
+;;;###autoload
+(defun github-clone-add-existing-remote (&optional parent-remote)
+  "Add a remote that is an existing fork of PARENT-REMOTE."
+  (interactive
+   (list (magit-read-remote "Select the remote whose network you would like to search")))
+  (cl-destructuring-bind (user . repo)
+      (github-clone-get-repo-name-from-remote parent-remote)
+    (let ((candidates (github-clone-remotes user repo)))
+      (cl-destructuring-bind (selected-user . selected-repo)
+          (assoc (completing-read "Select a remote to add: " candidates) candidates)
+        (magit-remote-add selected-user selected-repo)))))
+
 ;;;###autoload
 (defun github-clone (user-repo-url directory)
   "Fork and clone USER-REPO-URL into DIRECTORY.

--- a/github-clone.el
+++ b/github-clone.el
@@ -130,7 +130,7 @@
 
 ;;;###autoload
 (defun github-clone-add-source-remote (child-remote)
-  "Obtain the original repository of CHILD-REMOTE and add it as a remote."
+  "Obtain the original ancestor of CHILD-REMOTE and add it as a remote."
   (interactive (list (magit-read-remote "Select a child remote")))
   (github-clone-add-ancestor-remote child-remote :source))
 
@@ -176,7 +176,7 @@ USER-REPO-URL can be any of the forms:
   https://github.com/user/repository.el.git
 
 It will immediately clone the repository (as the origin) to
-DIRECTORY. Then it prompts to fork the repository and add a
+DIRECTORY.  Then it prompts to fork the repository and add a
 remote named after the github username to the fork."
   (interactive
    (list (read-from-minibuffer "Url or User/Repo: ")
@@ -189,7 +189,10 @@ remote named after the github username to the fork."
 
 ;;;###autoload
 (defun eshell/github-clone (user-repo-url &optional directory)
-  "Eshell alias uses current directory as default."
+  "An eshell alias for `github-clone'.
+
+Fork and clone USER-REPO-URL into DIRECTORY, which defaults to
+the current directory in eshell (`default-directory')."
   (funcall 'github-clone user-repo-url (or directory default-directory)))
 
 (provide 'github-clone)

--- a/github-clone.el
+++ b/github-clone.el
@@ -112,6 +112,28 @@
   (github-clone-repo-name
    (magit-get "remote" remote "url")))
 
+(defun github-clone-add-ancestor-remote (child-remote &optional parent-slot)
+  (cl-destructuring-bind (user . repo)
+      (github-clone-get-repo-name-from-remote child-remote)
+    (let* ((child-repo (github-clone-info user repo))
+           (ancestor-repo (eieio-oref child-repo parent-slot))
+           (remote-url (eieio-oref ancestor-repo github-clone-url-slot))
+           (owner (eieio-oref ancestor-repo :owner))
+           (owner-name (eieio-oref owner :login)))
+      (magit-remote-add owner-name remote-url))))
+
+;;;###autoload
+(defun github-clone-add-parent-remote (child-remote)
+  "Obtain the parent of CHILD-REMOTE and add it as a remote."
+  (interactive (list (magit-read-remote "Select a child remote")))
+  (github-clone-add-ancestor-remote child-remote :parent))
+
+;;;###autoload
+(defun github-clone-add-source-remote (child-remote)
+  "Obtain the original repository of CHILD-REMOTE and add it as a remote."
+  (interactive (list (magit-read-remote "Select a child remote")))
+  (github-clone-add-ancestor-remote child-remote :source))
+
 ;;;###autoload
 (defun github-clone-fork-remote (&optional remote)
   "Fork REMOTE to the current user."


### PR DESCRIPTION
It seems the functionality provided by this pull request was supposed to be a feature of github-clone, but for some reason or another, it never really came to fruition. Take a look at the detailed commit comments for clarifications about implementations etc.

~~I believe that I found an issue with gh.el's ability to actually populate the parent and source properties of gh-repo-repo objects, so jumping to the source repository from the original repository may not work as intended until that is resolved. I'll update here once I've filed an issue/submitted a pull request to gh.el.~~

EDIT: Seems like I was mistaken about gh.el. I think something must have gotten messed up with it as I was developing (and edebugging) some of its functions. Things should be good to go.