### PR TITLE
Allow user to specify default directory for repos

### DIFF
--- a/github-clone.el
+++ b/github-clone.el
@@ -48,6 +48,12 @@
                 (const :tag "Git" :git-url))
   :group 'github-clone)
 
+(defcustom github-clone-default-directory nil
+  "Where you want by default to save your cloned repos"
+  :type 'directory
+  :group 'github-clone)
+
+
 (defun github-clone-fork (repo)
   (oref (gh-repos-fork (gh-repos-api "api") repo) :data))
 
@@ -180,7 +186,7 @@ DIRECTORY.  Then it prompts to fork the repository and add a
 remote named after the github username to the fork."
   (interactive
    (list (read-from-minibuffer "Url or User/Repo: ")
-         (read-directory-name "Directory: " nil default-directory t)))
+         (read-directory-name "Directory: " github-clone-default-directory nil t)))
   (let* ((name (github-clone-repo-name user-repo-url))
          (repo (github-clone-info (car name) (cdr name))))
     (if (eieio-oref repo github-clone-url-slot)
@@ -193,7 +199,7 @@ remote named after the github username to the fork."
 
 Fork and clone USER-REPO-URL into DIRECTORY, which defaults to
 the current directory in eshell (`default-directory')."
-  (funcall 'github-clone user-repo-url (or directory default-directory)))
+  (funcall 'github-clone user-repo-url (or directory github-clone-default-directory default-directory)))
 
 (provide 'github-clone)
 ;;; github-clone.el ends here


### PR DESCRIPTION
Just an extra option of setting default repo directory when using `github-clone`

This might resolve issue #20 as well as my need to clone to a repo playground directory
