### PR TITLE
[IMP] Allow cloning stuff to nonexistent directories

### DIFF
--- a/github-clone.el
+++ b/github-clone.el
@@ -180,9 +180,11 @@ DIRECTORY.  Then it prompts to fork the repository and add a
 remote named after the github username to the fork."
   (interactive
    (list (read-from-minibuffer "Url or User/Repo: ")
-         (read-directory-name "Directory: " nil default-directory t)))
+         (read-directory-name "Directory: " nil default-directory)))
   (let* ((name (github-clone-repo-name user-repo-url))
          (repo (github-clone-info (car name) (cdr name))))
+    (unless (file-directory-p directory)
+      (make-directory directory t))
     (if (eieio-oref repo github-clone-url-slot)
         (github-clone-repo repo directory)
       (error "Repository %s does not exist" user-repo-url))))


### PR DESCRIPTION
As much as I like cloning repos to my machine, I like to group them by their original Github namespace, so every time I'm cloning something from a new user or group, it is obligatory to create a blank directory at the landing bay, and that has become somewhat a challenge for me :slightly_smiling_face: 
I wonder if I'm missing something and there is actually a reason to require an existing directory to clone a repo into?