### PR TITLE
Clone to default directory

### DIFF
--- a/github-clone.el
+++ b/github-clone.el
@@ -44,12 +44,6 @@
 ;; Silence unknown slot warnings during compilation
 (eieio-declare-slots :data :login :name :owner)
 
-(defcustom github-clone-dir (locate-user-emacs-file "github-clone")
-  "Default as clone destination directory.
-Using in`github-clone-in-default-directory'."
-  :type 'string
-  :group 'github-clone)
-
 (defcustom github-clone-url-slot :ssh-url
   "Which slot to use as the URL to clone."
   :type '(radio (const :tag "SSH" :ssh-url)
@@ -57,11 +51,11 @@ Using in`github-clone-in-default-directory'."
                 (const :tag "Git" :git-url))
   :group 'github-clone)
 
-(defcustom github-clone-default-directory nil
-  "Where you want by default to save your cloned repos"
+(defcustom github-clone-directory nil
+  "Default directory to clone new repos and forks to, if `nil'
+reverts to using `default-directory'."
   :type 'directory
   :group 'github-clone)
-
 
 (defun github-clone-fork (repo)
   (oref (gh-repos-fork (gh-repos-api) repo) :data))
@@ -196,7 +190,7 @@ DIRECTORY.  Then it prompts to fork the repository and add a
 remote named after the github username to the fork."
   (interactive
    (list (read-from-minibuffer "Url or User/Repo: ")
-         (read-directory-name "Directory: " github-clone-default-directory nil)))
+         (read-directory-name "Directory: " github-clone-directory)))
   (let* ((name (github-clone-repo-name user-repo-url))
          (repo (github-clone-info (car name) (cdr name))))
     (unless (file-directory-p directory)
@@ -207,7 +201,7 @@ remote named after the github username to the fork."
 
 ;;;###autoload
 (defun github-clone-in-default-directory (user-repo-url)
-  "Fork and clone USER-REPO-URL into `github-clone-dir'.
+  "Fork and clone USER-REPO-URL into `github-clone-directory'.
 
 USER-REPO-URL can be any of the forms:
 
@@ -219,13 +213,11 @@ USER-REPO-URL can be any of the forms:
   https://github.com/user/repository.el.git
 
 It will immediately clone the repository (as the origin) to
-`github-clone-dir'.  Then it prompts to fork the repository and
+`github-clone-directory'.  Then it prompts to fork the repository and
 add a remote named after the github username to the fork."
   (interactive
    (list (read-from-minibuffer "Url or User/Repo: ")))
-  (unless (file-directory-p github-clone-dir)
-    (make-directory github-clone-dir))
-  (apply #'github-clone `(,user-repo-url ,github-clone-dir)))
+  (apply #'github-clone `(,user-repo-url ,github-clone-directory)))
 
 ;;;###autoload
 (defun eshell/github-clone (user-repo-url &optional directory)
@@ -233,7 +225,7 @@ add a remote named after the github username to the fork."
 
 Fork and clone USER-REPO-URL into DIRECTORY, which defaults to
 the current directory in eshell (`default-directory')."
-  (funcall 'github-clone user-repo-url (or directory github-clone-default-directory default-directory)))
+  (funcall 'github-clone user-repo-url (or directory github-clone-directory default-directory)))
 
 (provide 'github-clone)
 ;;; github-clone.el ends here

--- a/github-clone.el
+++ b/github-clone.el
@@ -44,17 +44,17 @@
 ;; Silence unknown slot warnings during compilation
 (eieio-declare-slots :data :login :name :owner)
 
+(defcustom github-clone-directory nil
+  "Default directory to clone new repos and forks to, if `nil'
+reverts to using `default-directory'."
+  :type 'directory
+  :group 'github-clone)
+
 (defcustom github-clone-url-slot :ssh-url
   "Which slot to use as the URL to clone."
   :type '(radio (const :tag "SSH" :ssh-url)
                 (const :tag "HTTPS" :clone-url)
                 (const :tag "Git" :git-url))
-  :group 'github-clone)
-
-(defcustom github-clone-directory nil
-  "Default directory to clone new repos and forks to, if `nil'
-reverts to using `default-directory'."
-  :type 'directory
   :group 'github-clone)
 
 (defun github-clone-fork (repo)

--- a/github-clone.el
+++ b/github-clone.el
@@ -204,7 +204,8 @@ remote named after the github username to the fork."
   "An alias for `github-clone' with `github-clone-directory' as the default directory."
   (interactive
    (list (read-from-minibuffer "Url or User/Repo: ")))
-  (funcall 'github-clone user-repo-url (or github-clone-directory default-directory)))
+  (funcall 'github-clone user-repo-url
+           (or github-clone-directory default-directory)))
 
 ;;;###autoload
 (defun eshell/github-clone (user-repo-url &optional directory)
@@ -212,7 +213,8 @@ remote named after the github username to the fork."
 
 Fork and clone USER-REPO-URL into DIRECTORY, which defaults to
 the current directory in eshell (`default-directory')."
-  (funcall 'github-clone user-repo-url (or directory github-clone-directory default-directory)))
+  (funcall 'github-clone user-repo-url
+           (or directory github-clone-directory default-directory)))
 
 (provide 'github-clone)
 ;;; github-clone.el ends here

--- a/github-clone.el
+++ b/github-clone.el
@@ -4,7 +4,7 @@
 
 ;; Author: Charles L.G. Comstock <dgtized@gmail.com>
 ;; Created: 2 Aug 2014
-;; Version: 0.2
+;; Version: 0.3
 ;; URL: https://github.com/dgtized/github-clone.el
 ;; Keywords: vc, tools
 ;; Package-Requires: ((gh "1.0.1") (magit "3.0.0") (emacs "25.1"))
@@ -30,6 +30,9 @@
 
 ;;; Change Log:
 
+;;  0.3 2021-01-05 Support cloning to a `github-clone-directory' by default over
+;;                 current directory.
+;;
 ;;  0.2 2014-10-06 Switch to hub style cloning; always clone as origin, and
 ;;                 optionally add a remote to user's fork named after their
 ;;                 username. Removes support for 'upstream' style.

--- a/github-clone.el
+++ b/github-clone.el
@@ -201,23 +201,10 @@ remote named after the github username to the fork."
 
 ;;;###autoload
 (defun github-clone-in-default-directory (user-repo-url)
-  "Fork and clone USER-REPO-URL into `github-clone-directory'.
-
-USER-REPO-URL can be any of the forms:
-
-  repository
-  user/repository
-  organization/repository
-  https://github.com/user/repository
-  git@github.com:user/repository.git
-  https://github.com/user/repository.el.git
-
-It will immediately clone the repository (as the origin) to
-`github-clone-directory'.  Then it prompts to fork the repository and
-add a remote named after the github username to the fork."
+  "An alias for `github-clone' with `github-clone-directory' as the default directory."
   (interactive
    (list (read-from-minibuffer "Url or User/Repo: ")))
-  (apply #'github-clone `(,user-repo-url ,github-clone-directory)))
+  (funcall 'github-clone user-repo-url (or github-clone-directory default-directory)))
 
 ;;;###autoload
 (defun eshell/github-clone (user-repo-url &optional directory)

--- a/github-clone.el
+++ b/github-clone.el
@@ -201,7 +201,9 @@ remote named after the github username to the fork."
 
 ;;;###autoload
 (defun github-clone-in-default-directory (user-repo-url)
-  "An alias for `github-clone' with `github-clone-directory' as the default directory."
+  "Fork and clone USER-REPO-URL to `github-default-directory'.
+
+See `github-clone' for explanation of arguments."
   (interactive
    (list (read-from-minibuffer "Url or User/Repo: ")))
   (funcall 'github-clone user-repo-url


### PR DESCRIPTION
Merges all of the candidate solutions for #22, combining #21, #25, and #26 in a way that I *believe* handles all cases while still preserving the default case of prompting for repo and directory using default-directory as the starting location.

@conao3, @br3athein, and @FrancisMurillo, let me know if this works for you and I can merge this as the new default.

Also, my apologies on the extended hiatus of maintaining this project, thank you for submitting all your lovely suggestions and PRs.